### PR TITLE
Fix Editor.js is not ready because of Error: element with ID «editorj…

### DIFF
--- a/src/Model/Editor.php
+++ b/src/Model/Editor.php
@@ -17,6 +17,7 @@ class Editor
     public function __construct(
         private readonly string $id = 'editorjs'
     ) {
+        $this->holder($this->id);
     }
 
     /**


### PR DESCRIPTION
…s» is missing. Pass correct holder's ID.